### PR TITLE
fix: correctly terminate container on SIGINT even when Ryuk is disabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaqx0r/itestcontainer
 
-go 1.26.2
+go 1.26.1
 
 require github.com/testcontainers/testcontainers-go v0.42.0
 

--- a/itestcontainer.go
+++ b/itestcontainer.go
@@ -13,20 +13,17 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"flag"
 	"fmt"
 	"log"
-	"net/netip"
 	"os"
 	"os/signal"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
 )
 
@@ -36,10 +33,22 @@ var (
 	env    = flag.String("env", "", "KEY[,KEY] list of environment variable names to pass through to the container")
 	ports  = flag.String("ports", "", "exposed port mappings to pass to container")
 	labels = flag.String("labels", "", "labels to set on container")
+	cmd    = flag.String("cmd", "", "command to run in container (space-separated)")
 )
 
-type logConsumer struct {
+// Config holds all parameters needed to launch a container.
+type Config struct {
+	Name       string
+	Ports      string
+	Env        string
+	Volume     string
+	Labels     string
+	Cmd        string
+	TestTarget string
+	EnvLookup  func(string) (string, bool)
 }
+
+type logConsumer struct{}
 
 func (logConsumer) Accept(l testcontainers.Log) {
 	log.Printf("%s: %s", l.LogType, l.Content)
@@ -48,118 +57,104 @@ func (logConsumer) Accept(l testcontainers.Log) {
 func main() {
 	flag.Parse()
 
-	if *name == "" {
-		log.Fatal("`name` must be set")
+	cfg := Config{
+		Name:       *name,
+		Ports:      *ports,
+		Env:        *env,
+		Volume:     *volume,
+		Labels:     *labels,
+		Cmd:        *cmd,
+		TestTarget: os.Getenv("TEST_TARGET"),
+		EnvLookup:  os.LookupEnv,
 	}
 
+	if err := run(cfg); err != nil {
+		log.Print(err)
+		os.Exit(1)
+	}
+}
+
+func run(cfg Config) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	wg := sync.WaitGroup{}
+	defer stop()
+	return runWithContext(ctx, stop, cfg)
+}
 
-	exposedPorts := make([]string, 0)
-	portBindings := network.PortMap{}
-	for portMap := range strings.SplitSeq(*ports, ",") {
-		if portMap == "" {
-			continue
-		}
-		portPair := strings.Split(portMap, ":")
-		if len(portPair) != 2 {
-			continue
-		}
-		exposedPorts = append(exposedPorts, portPair[1])
-		portBindings[network.MustParsePort(portPair[1])] = []network.PortBinding{
-			{
-				HostIP:   netip.MustParseAddr("127.0.0.1"),
-				HostPort: portPair[0],
-			},
-		}
+func runWithContext(ctx context.Context, stop context.CancelFunc, cfg Config) error {
+	if cfg.Name == "" {
+		return fmt.Errorf("`name` must be set")
+	}
 
+	exposedPorts, portBindings, err := parsePorts(cfg.Ports)
+	if err != nil {
+		return fmt.Errorf("parsePorts: %w", err)
 	}
 	log.Println("Exposed Ports:", exposedPorts)
 
-	environment := make(map[string]string, 0)
-	for envVar := range strings.SplitSeq(*env, ",") {
-		if envVar == "" {
-			continue
-		}
-		value := os.Getenv(envVar)
-		if value == "" {
-			log.Fatalf("No environment variable found: %q", envVar)
-		}
-		environment[envVar] = value
+	environment, err := parseEnvironment(cfg.Env, cfg.EnvLookup)
+	if err != nil {
+		return fmt.Errorf("parseEnvironment: %w", err)
 	}
 	log.Println("Environment:", environment)
 
-	// Create a mount name suffix for the volume based on TEST_TARGET.
-	suffix := ""
-	testTarget := os.Getenv("TEST_TARGET")
-	if testTarget != "" {
-		hasher := sha256.New()
-		hasher.Write([]byte(testTarget))
-		hB := hasher.Sum(nil)
-		suffix = hex.EncodeToString(hB)
-	}
-	mounts := make([]testcontainers.ContainerMount, 0)
-	for volumeMount := range strings.SplitSeq(*volume, ",") {
-		if volumeMount == "" {
-			continue
-		}
-		parts := strings.SplitN(volumeMount, ":", 2)
-		volumeName := ""
-		if suffix != "" {
-			volumeName = fmt.Sprintf("bazel-itest-%s-%s", parts[0], suffix)
-		} else {
-			volumeName = fmt.Sprintf("bazel-itest-%s", parts[0])
-		}
-		mounts = append(mounts,
-			testcontainers.ContainerMount{
-				Source: testcontainers.GenericVolumeMountSource{Name: volumeName},
-				Target: testcontainers.ContainerMountTarget(parts[1]),
-			})
-	}
+	suffix := volumeSuffix(cfg.TestTarget)
+	mounts := parseVolumes(cfg.Volume, suffix)
 	log.Println("Volume Mounts:", mounts)
 
-	labelMap := make(map[string]string, 0)
-	for label := range strings.SplitSeq(*labels, ",") {
-		if label == "" {
-			continue
-		}
-		pair := strings.SplitN(label, "=", 2)
-		labelMap[pair[0]] = pair[1]
+	labelMap, err := parseLabels(cfg.Labels)
+	if err != nil {
+		return fmt.Errorf("parseLabels: %w", err)
 	}
 	log.Println("Labels:", labelMap)
 
-	logConsumer := logConsumer{}
+	lc := logConsumer{}
 
-	c, err := testcontainers.Run(ctx, *name,
+	opts := []testcontainers.ContainerCustomizer{
 		testcontainers.WithExposedPorts(exposedPorts...),
 		testcontainers.WithHostConfigModifier(func(hostConfig *container.HostConfig) {
 			hostConfig.PortBindings = portBindings
 		}),
-		testcontainers.WithLogConsumers(logConsumer),
+		testcontainers.WithLogConsumers(lc),
 		testcontainers.WithEnv(environment),
 		testcontainers.WithMounts(mounts...),
 		testcontainers.WithLabels(labelMap),
-	)
-	if err != nil {
-		log.Fatalf("testcontainers.Run(%v): %v", *name, err)
 	}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		<-ctx.Done()
-		name := c.GetContainerID()
-		n, err := c.Inspect(context.Background())
-		if err == nil {
-			name = n.Name
-		}
-		log.Println("Stopping ", name)
-		testcontainers.TerminateContainer(c)
-	}()
-	log.Println("Started", *name)
+	if cfg.Cmd != "" {
+		opts = append(opts, testcontainers.WithCmd(strings.Fields(cfg.Cmd)...))
+	}
+
+	c, err := testcontainers.Run(ctx, cfg.Name, opts...)
+
+	wg := sync.WaitGroup{}
+	if c != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-ctx.Done()
+			containerName := c.GetContainerID()
+			inspectCtx, inspectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer inspectCancel()
+			if n, inspectErr := c.Inspect(inspectCtx); inspectErr == nil {
+				containerName = n.Name
+			}
+			log.Println("Stopping", containerName)
+			if termErr := testcontainers.TerminateContainer(c); termErr != nil {
+				log.Printf("failed to terminate container %s: %v", containerName, termErr)
+			}
+		}()
+	}
+
+	if err != nil {
+		stop()
+		wg.Wait()
+		return fmt.Errorf("testcontainers.Run(%v): %w", cfg.Name, err)
+	}
+
+	log.Println("Started", cfg.Name)
 	log.Println("Waiting, press Ctrl-C to shutdown")
 	<-ctx.Done()
 	stop()
-
 	wg.Wait()
 	log.Println("itestcontainer done")
+	return nil
 }

--- a/itestcontainer_test.go
+++ b/itestcontainer_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+)
+
+func TestRunWithContextTerminatesContainer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Docker")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := Config{
+		Name:      "alpine:latest",
+		Cmd:       "sleep infinity",
+		Labels:    "itestcontainer-test=TestRunWithContextTerminatesContainer",
+		EnvLookup: func(s string) (string, bool) { return "", false },
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runWithContext(ctx, cancel, cfg)
+	}()
+
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+	defer dockerClient.Close()
+
+	started := make(chan struct{})
+	deadline := time.Now().Add(30 * time.Second)
+	var containerID string
+	for time.Now().Before(deadline) {
+		result, err := dockerClient.ContainerList(context.Background(), client.ContainerListOptions{
+			Filters: make(client.Filters).Add("label", "itestcontainer-test=TestRunWithContextTerminatesContainer"),
+		})
+		if err != nil {
+			t.Fatalf("ContainerList: %v", err)
+		}
+		if len(result.Items) > 0 && result.Items[0].State == container.StateRunning {
+			containerID = result.Items[0].ID
+			close(started)
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	select {
+	case <-started:
+	default:
+		t.Fatal("container did not start within 30s")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("runWithContext returned error: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runWithContext did not return within 30s after cancel")
+	}
+
+	result, err := dockerClient.ContainerList(context.Background(), client.ContainerListOptions{
+		All:     true,
+		Filters: make(client.Filters).Add("label", "itestcontainer-test=TestRunWithContextTerminatesContainer"),
+	})
+	if err != nil {
+		t.Fatalf("ContainerList: %v", err)
+	}
+	if len(result.Items) != 0 {
+		t.Errorf("container still exists after cancel: %v", containerID)
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/moby/moby/api/types/network"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+// parsePorts parses "hostPort:containerPort/proto,..." into exposed ports list and port bindings map.
+// Returns error on malformed input.
+func parsePorts(raw string) ([]string, network.PortMap, error) {
+	exposedPorts := make([]string, 0)
+	portBindings := network.PortMap{}
+
+	for portMap := range strings.SplitSeq(raw, ",") {
+		if portMap == "" {
+			continue
+		}
+		portPair := strings.Split(portMap, ":")
+		if len(portPair) != 2 {
+			continue
+		}
+		port, portErr := network.ParsePort(portPair[1])
+		if portErr != nil {
+			return nil, nil, fmt.Errorf("invalid port %q: %w", portPair[1], portErr)
+		}
+		exposedPorts = append(exposedPorts, portPair[1])
+		portBindings[port] = []network.PortBinding{
+			{
+				HostIP:   netip.MustParseAddr("127.0.0.1"),
+				HostPort: portPair[0],
+			},
+		}
+	}
+
+	return exposedPorts, portBindings, nil
+}
+
+// parseEnvironment parses a comma-separated list of env var names, looking up each via lookup.
+// Returns error if any var is not set.
+func parseEnvironment(raw string, lookup func(string) (string, bool)) (map[string]string, error) {
+	environment := make(map[string]string)
+
+	for envVar := range strings.SplitSeq(raw, ",") {
+		if envVar == "" {
+			continue
+		}
+		value, ok := lookup(envVar)
+		if !ok {
+			return nil, fmt.Errorf("environment variable not set: %q", envVar)
+		}
+		environment[envVar] = value
+	}
+
+	return environment, nil
+}
+
+// volumeSuffix returns a hex-encoded sha256 of testTarget, or "" if testTarget is empty.
+func volumeSuffix(testTarget string) string {
+	if testTarget == "" {
+		return ""
+	}
+	hasher := sha256.New()
+	hasher.Write([]byte(testTarget))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// parseVolumes parses "name:path,..." volume mount specs, prepending "bazel-itest-" and suffix.
+func parseVolumes(raw string, suffix string) []testcontainers.ContainerMount {
+	mounts := make([]testcontainers.ContainerMount, 0)
+
+	for volumeMount := range strings.SplitSeq(raw, ",") {
+		if volumeMount == "" {
+			continue
+		}
+		parts := strings.SplitN(volumeMount, ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		var volumeName string
+		if suffix != "" {
+			volumeName = fmt.Sprintf("bazel-itest-%s-%s", parts[0], suffix)
+		} else {
+			volumeName = fmt.Sprintf("bazel-itest-%s", parts[0])
+		}
+		mounts = append(mounts, testcontainers.ContainerMount{
+			Source: testcontainers.GenericVolumeMountSource{Name: volumeName},
+			Target: testcontainers.ContainerMountTarget(parts[1]),
+		})
+	}
+
+	return mounts
+}
+
+// parseLabels parses "key=val,..." label specs into a map.
+// Returns error if a label has no "=" separator.
+func parseLabels(raw string) (map[string]string, error) {
+	labelMap := make(map[string]string)
+
+	for label := range strings.SplitSeq(raw, ",") {
+		if label == "" {
+			continue
+		}
+		pair := strings.SplitN(label, "=", 2)
+		if len(pair) < 2 {
+			return nil, fmt.Errorf("malformed label %q: missing '='", label)
+		}
+		labelMap[pair[0]] = pair[1]
+	}
+
+	return labelMap, nil
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/moby/moby/api/types/network"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+func TestParsePorts(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		wantExposedCount int
+		wantBindingKey   network.Port
+		wantHostPort     string
+		wantErr          bool
+	}{
+		{
+			name:             "empty string",
+			input:            "",
+			wantExposedCount: 0,
+		},
+		{
+			name:             "single port mapping",
+			input:            "8080:80/tcp",
+			wantExposedCount: 1,
+			wantBindingKey:   network.MustParsePort("80/tcp"),
+			wantHostPort:     "8080",
+		},
+		{
+			name:             "two port mappings",
+			input:            "8080:80/tcp,9090:90/tcp",
+			wantExposedCount: 2,
+		},
+		{
+			name:             "malformed no colon skipped",
+			input:            "8080",
+			wantExposedCount: 0,
+		},
+		{
+			name:    "invalid container port",
+			input:   "8080:notaport",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exposed, bindings, err := parsePorts(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(exposed) != tc.wantExposedCount {
+				t.Errorf("exposed ports: got %d, want %d", len(exposed), tc.wantExposedCount)
+			}
+			if tc.wantHostPort != "" {
+				binding, ok := bindings[tc.wantBindingKey]
+				if !ok {
+					t.Fatalf("binding for %v not found", tc.wantBindingKey)
+				}
+				if len(binding) == 0 || binding[0].HostPort != tc.wantHostPort {
+					t.Errorf("host port: got %v, want %s", binding, tc.wantHostPort)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEnvironment(t *testing.T) {
+	lookup := func(vars map[string]string) func(string) (string, bool) {
+		return func(k string) (string, bool) {
+			v, ok := vars[k]
+			return v, ok
+		}
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		env     map[string]string
+		wantMap map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			env:     map[string]string{},
+			wantMap: map[string]string{},
+		},
+		{
+			name:    "single var set",
+			input:   "FOO",
+			env:     map[string]string{"FOO": "bar"},
+			wantMap: map[string]string{"FOO": "bar"},
+		},
+		{
+			name:    "var not set",
+			input:   "MISSING",
+			env:     map[string]string{},
+			wantErr: true,
+		},
+		{
+			name:    "multiple vars one missing",
+			input:   "FOO,MISSING",
+			env:     map[string]string{"FOO": "bar"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseEnvironment(tc.input, lookup(tc.env))
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for k, v := range tc.wantMap {
+				if got[k] != v {
+					t.Errorf("env[%s]: got %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestVolumeSuffix(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name: "non-empty target",
+			input: "//some:target",
+			want: func() string {
+				h := sha256.New()
+				h.Write([]byte("//some:target"))
+				return hex.EncodeToString(h.Sum(nil))
+			}(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := volumeSuffix(tc.input)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+			if tc.input != "" && len(got) != 64 {
+				t.Errorf("expected 64-char hex, got len=%d", len(got))
+			}
+		})
+	}
+}
+
+func TestParseVolumes(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		suffix      string
+		wantCount   int
+		wantNames   []string
+		wantTargets []string
+	}{
+		{
+			name:      "empty string",
+			input:     "",
+			wantCount: 0,
+		},
+		{
+			name:        "single volume no suffix",
+			input:       "data:/app/data",
+			suffix:      "",
+			wantCount:   1,
+			wantNames:   []string{"bazel-itest-data"},
+			wantTargets: []string{"/app/data"},
+		},
+		{
+			name:        "single volume with suffix",
+			input:       "data:/app/data",
+			suffix:      "abc123",
+			wantCount:   1,
+			wantNames:   []string{"bazel-itest-data-abc123"},
+			wantTargets: []string{"/app/data"},
+		},
+		{
+			name:        "multiple volumes",
+			input:       "data:/app/data,logs:/app/logs",
+			suffix:      "",
+			wantCount:   2,
+			wantNames:   []string{"bazel-itest-data", "bazel-itest-logs"},
+			wantTargets: []string{"/app/data", "/app/logs"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseVolumes(tc.input, tc.suffix)
+			if len(got) != tc.wantCount {
+				t.Fatalf("mount count: got %d, want %d", len(got), tc.wantCount)
+			}
+			for i, m := range got {
+				src, ok := m.Source.(testcontainers.GenericVolumeMountSource)
+				if !ok {
+					t.Fatalf("mount[%d] source not GenericVolumeMountSource", i)
+				}
+				if src.Name != tc.wantNames[i] {
+					t.Errorf("mount[%d] name: got %q, want %q", i, src.Name, tc.wantNames[i])
+				}
+				if string(m.Target) != tc.wantTargets[i] {
+					t.Errorf("mount[%d] target: got %q, want %q", i, m.Target, tc.wantTargets[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantMap map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			wantMap: map[string]string{},
+		},
+		{
+			name:    "single label",
+			input:   "key=val",
+			wantMap: map[string]string{"key": "val"},
+		},
+		{
+			name:    "two labels",
+			input:   "key=val,key2=val2",
+			wantMap: map[string]string{"key": "val", "key2": "val2"},
+		},
+		{
+			name:    "no equals sign",
+			input:   "noequals",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseLabels(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for k, v := range tc.wantMap {
+				if got[k] != v {
+					t.Errorf("label[%s]: got %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a bug where SIGINT during `testcontainers.Run` (e.g. slow image pull) could leave orphan containers running when the Ryuk reaper is disabled.

### Root cause

The cleanup goroutine was only registered after `testcontainers.Run` returned successfully. If SIGINT arrived during the pull, the context was cancelled, `Run` returned an error, and `log.Fatalf` exited immediately — the cleanup goroutine was never registered, so any partially-created container was left behind with no cleanup mechanism.

### Fix

Register the cleanup goroutine immediately when `c != nil`, before inspecting the error. This ensures `TerminateContainer` is always called if a container handle is available, regardless of whether `Run` succeeded.

### Changes

- `itestcontainer.go`: Refactor `main()` → `main()` + `run()` + `runWithContext()` with `Config` struct; cleanup goroutine registered on `c != nil`; all `log.Fatalf` replaced with returned errors
- `parse.go`: Extract port/env/volume/label parsing into pure testable functions; replace `MustParsePort` with `ParsePort`; guard against malformed volume specs
- `parse_test.go`: Table-driven unit tests for all parse functions
- `itestcontainer_test.go`: Integration test verifying container is terminated when context is cancelled
- `go.mod`: Downgrade Go directive to 1.26.1