### PR TITLE
fix: skip pull when image already exists locally in Docker runtime

### DIFF
--- a/internal/containerd/containerd.go
+++ b/internal/containerd/containerd.go
@@ -89,9 +89,13 @@ func (r *ContainerdRuntime) Close() error {
 func (r *ContainerdRuntime) Run(ctx context.Context, opts runtime.RunOptions) (runtime.Container, error) {
 	ctx = namespaces.WithNamespace(ctx, itestNamespace)
 
-	image, err := r.client.Pull(ctx, opts.Image, containerdclient.WithPullUnpack)
+	image, err := r.client.GetImage(ctx, opts.Image)
 	if err != nil {
-		return nil, fmt.Errorf("pull %s: %w", opts.Image, err)
+		// Not found locally, pull from registry
+		image, err = r.client.Pull(ctx, opts.Image, containerdclient.WithPullUnpack)
+		if err != nil {
+			return nil, fmt.Errorf("pull %s: %w", opts.Image, err)
+		}
 	}
 
 	containerID := generateID()

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -72,6 +72,10 @@ func (r *DockerRuntime) Run(ctx context.Context, opts runtime.RunOptions) (runti
 }
 
 func (r *DockerRuntime) pullImage(ctx context.Context, image string) error {
+	_, err := r.client.ImageInspect(ctx, image)
+	if err == nil {
+		return nil // image exists locally, skip pull
+	}
 	resp, err := r.client.ImagePull(ctx, image, mobyclient.ImagePullOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

When images are loaded locally (e.g. via Bazel's `rules_oci` load task), they exist in the local runtime store but not on any registry. Both runtimes previously pulled unconditionally, causing `not found` failures for locally-loaded images.

### Docker runtime
Call `ImageInspect` first; skip `ImagePull` if image is present locally.

### containerd runtime
Call `GetImage` first; skip `Pull` if image is present in the local image store.

Closes #14