### PR TITLE
test: add unit tests for skip-pull-when-local logic

### DIFF
--- a/internal/containerd/containerd.go
+++ b/internal/containerd/containerd.go
@@ -54,9 +54,17 @@ var bridgeCNIConfig = []byte(`{
   ]
 }`)
 
+// containerdClient is the subset of containerdclient.Client methods used by ContainerdRuntime.
+type containerdClient interface {
+	GetImage(ctx context.Context, ref string) (containerdclient.Image, error)
+	Pull(ctx context.Context, ref string, opts ...containerdclient.RemoteOpt) (containerdclient.Image, error)
+	NewContainer(ctx context.Context, id string, opts ...containerdclient.NewContainerOpts) (containerdclient.Container, error)
+	Close() error
+}
+
 // ContainerdRuntime implements runtime.Runtime using containerd.
 type ContainerdRuntime struct {
-	client *containerdclient.Client
+	client containerdClient
 	cni    gocni.CNI
 }
 
@@ -84,18 +92,28 @@ func (r *ContainerdRuntime) Close() error {
 	return r.client.Close()
 }
 
+// pullImage returns the local image if it exists, otherwise pulls from registry.
+func (r *ContainerdRuntime) pullImage(ctx context.Context, ref string) (containerdclient.Image, error) {
+	image, err := r.client.GetImage(ctx, ref)
+	if err == nil {
+		return image, nil
+	}
+	// Not found locally — pull from registry.
+	image, err = r.client.Pull(ctx, ref, containerdclient.WithPullUnpack)
+	if err != nil {
+		return nil, fmt.Errorf("pull %s: %w", ref, err)
+	}
+	return image, nil
+}
+
 // Run pulls the image, creates a container and task, sets up CNI networking,
 // and starts the task.
 func (r *ContainerdRuntime) Run(ctx context.Context, opts runtime.RunOptions) (runtime.Container, error) {
 	ctx = namespaces.WithNamespace(ctx, itestNamespace)
 
-	image, err := r.client.GetImage(ctx, opts.Image)
+	image, err := r.pullImage(ctx, opts.Image)
 	if err != nil {
-		// Not found locally, pull from registry
-		image, err = r.client.Pull(ctx, opts.Image, containerdclient.WithPullUnpack)
-		if err != nil {
-			return nil, fmt.Errorf("pull %s: %w", opts.Image, err)
-		}
+		return nil, err
 	}
 
 	containerID := generateID()

--- a/internal/containerd/containerd_test.go
+++ b/internal/containerd/containerd_test.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package containerd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	containerdclient "github.com/containerd/containerd/v2/client"
+)
+
+// fakeContainerdClient implements containerdClient for unit tests.
+type fakeContainerdClient struct {
+	getImageErr error
+	pullCalled  bool
+	pullErr     error
+}
+
+func (f *fakeContainerdClient) GetImage(_ context.Context, _ string) (containerdclient.Image, error) {
+	if f.getImageErr != nil {
+		return nil, f.getImageErr
+	}
+	return nil, nil
+}
+
+func (f *fakeContainerdClient) Pull(_ context.Context, _ string, _ ...containerdclient.RemoteOpt) (containerdclient.Image, error) {
+	f.pullCalled = true
+	if f.pullErr != nil {
+		return nil, f.pullErr
+	}
+	return nil, nil
+}
+
+func (f *fakeContainerdClient) NewContainer(_ context.Context, _ string, _ ...containerdclient.NewContainerOpts) (containerdclient.Container, error) {
+	return nil, nil
+}
+
+func (f *fakeContainerdClient) Close() error { return nil }
+
+func TestGetImage_LocalExists(t *testing.T) {
+	fake := &fakeContainerdClient{getImageErr: nil}
+	r := &ContainerdRuntime{client: fake}
+
+	_, err := r.pullImage(context.Background(), "test/image:latest")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fake.pullCalled {
+		t.Fatal("expected Pull not to be called when image exists locally")
+	}
+}
+
+func TestGetImage_LocalMissing_PullSucceeds(t *testing.T) {
+	fake := &fakeContainerdClient{
+		getImageErr: errors.New("not found"),
+		pullErr:     nil,
+	}
+	r := &ContainerdRuntime{client: fake}
+
+	_, err := r.pullImage(context.Background(), "test/image:latest")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !fake.pullCalled {
+		t.Fatal("expected Pull to be called when image is missing locally")
+	}
+}
+
+func TestGetImage_LocalMissing_PullFails(t *testing.T) {
+	fake := &fakeContainerdClient{
+		getImageErr: errors.New("not found"),
+		pullErr:     errors.New("registry error"),
+	}
+	r := &ContainerdRuntime{client: fake}
+
+	_, err := r.pullImage(context.Background(), "test/image:latest")
+	if err == nil {
+		t.Fatal("expected error when pull fails, got nil")
+	}
+}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -14,9 +14,21 @@ import (
 	"github.com/moby/moby/api/pkg/stdcopy"
 )
 
+// dockerClient is the subset of mobyclient.Client methods used by DockerRuntime.
+type dockerClient interface {
+	Close() error
+	ImageInspect(ctx context.Context, imageID string, opts ...mobyclient.ImageInspectOption) (mobyclient.ImageInspectResult, error)
+	ImagePull(ctx context.Context, refStr string, options mobyclient.ImagePullOptions) (mobyclient.ImagePullResponse, error)
+	ContainerCreate(ctx context.Context, options mobyclient.ContainerCreateOptions) (mobyclient.ContainerCreateResult, error)
+	ContainerStart(ctx context.Context, containerID string, options mobyclient.ContainerStartOptions) (mobyclient.ContainerStartResult, error)
+	ContainerStop(ctx context.Context, containerID string, options mobyclient.ContainerStopOptions) (mobyclient.ContainerStopResult, error)
+	ContainerRemove(ctx context.Context, containerID string, options mobyclient.ContainerRemoveOptions) (mobyclient.ContainerRemoveResult, error)
+	ContainerLogs(ctx context.Context, containerID string, options mobyclient.ContainerLogsOptions) (mobyclient.ContainerLogsResult, error)
+}
+
 // DockerRuntime implements runtime.Runtime using the moby Docker client.
 type DockerRuntime struct {
-	client *mobyclient.Client
+	client dockerClient
 }
 
 // New creates a DockerRuntime using environment-configured Docker connection.
@@ -153,7 +165,7 @@ func (r *DockerRuntime) buildHostConfig(opts runtime.RunOptions) (*mobycontainer
 
 // dockerContainer is a running Docker container handle.
 type dockerContainer struct {
-	client *mobyclient.Client
+	client dockerClient
 	id     string
 }
 

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -1,0 +1,107 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"iter"
+	"testing"
+
+	"github.com/moby/moby/api/types/jsonstream"
+	mobyclient "github.com/moby/moby/client"
+)
+
+// fakeImagePullResponse implements mobyclient.ImagePullResponse for tests.
+type fakeImagePullResponse struct {
+	waitErr error
+}
+
+func (f *fakeImagePullResponse) Read(_ []byte) (int, error)                                  { return 0, io.EOF }
+func (f *fakeImagePullResponse) Close() error                                                 { return nil }
+func (f *fakeImagePullResponse) JSONMessages(_ context.Context) iter.Seq2[jsonstream.Message, error] {
+	return func(yield func(jsonstream.Message, error) bool) {}
+}
+func (f *fakeImagePullResponse) Wait(_ context.Context) error { return f.waitErr }
+
+// fakeDockerClient implements dockerClient for unit tests.
+type fakeDockerClient struct {
+	inspectErr  error
+	pullCalled  bool
+	pullErr     error
+}
+
+func (f *fakeDockerClient) Close() error { return nil }
+
+func (f *fakeDockerClient) ImageInspect(_ context.Context, _ string, _ ...mobyclient.ImageInspectOption) (mobyclient.ImageInspectResult, error) {
+	return mobyclient.ImageInspectResult{}, f.inspectErr
+}
+
+func (f *fakeDockerClient) ImagePull(_ context.Context, _ string, _ mobyclient.ImagePullOptions) (mobyclient.ImagePullResponse, error) {
+	f.pullCalled = true
+	if f.pullErr != nil {
+		return nil, f.pullErr
+	}
+	return &fakeImagePullResponse{}, nil
+}
+
+func (f *fakeDockerClient) ContainerCreate(_ context.Context, _ mobyclient.ContainerCreateOptions) (mobyclient.ContainerCreateResult, error) {
+	return mobyclient.ContainerCreateResult{}, nil
+}
+
+func (f *fakeDockerClient) ContainerStart(_ context.Context, _ string, _ mobyclient.ContainerStartOptions) (mobyclient.ContainerStartResult, error) {
+	return mobyclient.ContainerStartResult{}, nil
+}
+
+func (f *fakeDockerClient) ContainerStop(_ context.Context, _ string, _ mobyclient.ContainerStopOptions) (mobyclient.ContainerStopResult, error) {
+	return mobyclient.ContainerStopResult{}, nil
+}
+
+func (f *fakeDockerClient) ContainerRemove(_ context.Context, _ string, _ mobyclient.ContainerRemoveOptions) (mobyclient.ContainerRemoveResult, error) {
+	return mobyclient.ContainerRemoveResult{}, nil
+}
+
+func (f *fakeDockerClient) ContainerLogs(_ context.Context, _ string, _ mobyclient.ContainerLogsOptions) (mobyclient.ContainerLogsResult, error) {
+	return nil, nil
+}
+
+func TestPullImage_LocalExists(t *testing.T) {
+	fake := &fakeDockerClient{inspectErr: nil}
+	r := &DockerRuntime{client: fake}
+
+	err := r.pullImage(context.Background(), "test/image:latest")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fake.pullCalled {
+		t.Fatal("expected ImagePull not to be called when image exists locally")
+	}
+}
+
+func TestPullImage_LocalMissing_PullSucceeds(t *testing.T) {
+	fake := &fakeDockerClient{
+		inspectErr: errors.New("not found"),
+		pullErr:    nil,
+	}
+	r := &DockerRuntime{client: fake}
+
+	err := r.pullImage(context.Background(), "test/image:latest")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !fake.pullCalled {
+		t.Fatal("expected ImagePull to be called when image is missing locally")
+	}
+}
+
+func TestPullImage_LocalMissing_PullFails(t *testing.T) {
+	fake := &fakeDockerClient{
+		inspectErr: errors.New("not found"),
+		pullErr:    errors.New("registry error"),
+	}
+	r := &DockerRuntime{client: fake}
+
+	err := r.pullImage(context.Background(), "test/image:latest")
+	if err == nil {
+		t.Fatal("expected error when pull fails, got nil")
+	}
+}


### PR DESCRIPTION
Add unit tests for the local-image check in both Docker and containerd runtimes.

Tests verify that:
- `pullImage` skips registry pull when image exists locally
- `pullImage` attempts registry pull when image is not found locally
- `pullImage` propagates pull errors correctly

Depends on / related to #99.