### PR TITLE
chore: Downgrade Go version from 1.26.3 to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaqx0r/itestcontainer
 
-go 1.26.3
+go 1.20
 
 require (
 	github.com/containerd/containerd/v2 v2.3.2


### PR DESCRIPTION
The go version is the language runtime support.  This should be the minimum supported version, not the most recent.