### PR TITLE
fix: Only pull images if explicitly asked.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@
 | `docker`     | moby/moby client  | Docker bridge networking |
 | `containerd` | containerd/v2     | CNI (bridge + portmap)   |
 
+By default, `itestcontainer` expects images to be pre-loaded into the container runtime.
+
 By default, `itestcontainer` auto-detects the runtime: it probes the containerd socket first (`/run/containerd/containerd.sock`), then falls back to Docker (`DOCKER_HOST` or `/var/run/docker.sock`). Override with `--runtime=docker` or `--runtime=containerd`.
+
+### Image Pulling
+`itestcontainer` assumes images are available in the local runtime cache. If an image is missing, it will fail to start.
+
+You can enable automatic image pulling by using the `PullImages` flag in `RunOptions` (if using as a Go library) or via corresponding command-line flags. This functionality should be used sparingly or only for local development, as it introduces external dependencies during test execution.
 
 ### containerd Prerequisites
 
@@ -25,9 +32,12 @@ By default, `itestcontainer` auto-detects the runtime: it probes the containerd 
 | `--name`    | Container image to start (required)                                       |
 | `--runtime` | Runtime backend: `docker` or `containerd` (default: auto-detect)         |
 | `--ports`   | Port mappings, comma-separated `<host>:<container>` (e.g. `8080:80/tcp`) |
+| `--pull-images` | Enable automatic image pulling if not found locally (default: false). |
 | `--env`     | Environment variables to pass through, comma-separated                    |
 | `--volume`  | Volume mounts, comma-separated `<source>:<target>`                        |
 | `--labels`  | Container labels, comma-separated `<key>=<value>`                         |
+
+By default, `itestcontainer` assumes images are already loaded into the container runtime. The `--pull-images` flag should only be used if automatic pulling is required for local development workflows.
 
 Example:
 

--- a/internal/containerd/containerd.go
+++ b/internal/containerd/containerd.go
@@ -89,12 +89,18 @@ func (r *ContainerdRuntime) Close() error {
 func (r *ContainerdRuntime) Run(ctx context.Context, opts runtime.RunOptions) (runtime.Container, error) {
 	ctx = namespaces.WithNamespace(ctx, itestNamespace)
 
-	image, err := r.client.GetImage(ctx, opts.Image)
-	if err != nil {
-		// Not found locally, pull from registry
+	var image containerdclient.Image
+	var err error
+
+	if opts.PullImages {
 		image, err = r.client.Pull(ctx, opts.Image, containerdclient.WithPullUnpack)
 		if err != nil {
 			return nil, fmt.Errorf("pull %s: %w", opts.Image, err)
+		}
+	} else {
+		image, err = r.client.GetImage(ctx, opts.Image)
+		if err != nil {
+			return nil, fmt.Errorf("image %s not found: %w", opts.Image, err)
 		}
 	}
 

--- a/internal/containerd/containerd_test.go
+++ b/internal/containerd/containerd_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package containerd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jaqx0r/itestcontainer/internal/runtime"
+)
+
+
+func TestRun_InvalidImage_NoPull(t *testing.T) {
+	ctx := context.Background()
+	r, err := New(ctx)
+	if err != nil {
+		t.Fatalf("Failed to initialize ContainerdRuntime: %v", err)
+	}
+	defer r.Close()
+
+	opts := runtime.RunOptions{
+		Image:      "non-existent-image-name-12345",
+		PullImages: false,
+	}
+
+	_, err = r.Run(ctx, opts)
+	if err == nil {
+		t.Error("Expected error when running non-existent image with PullImages: false, but got none")
+	}
+}
+
+func TestRun_InvalidImage_WithPull(t *testing.T) {
+	ctx := context.Background()
+	r, err := New(ctx)
+	if err != nil {
+		t.Fatalf("Failed to initialize ContainerdRuntime: %v", err)
+	}
+	defer r.Close()
+
+	// Use an image name that is structurally valid but unlikely to exist.
+	// If PullImages is true, we expect the containerd client to attempt
+	// to contact the registry.
+	opts := runtime.RunOptions{
+		Image:      "docker.io/library/non-existent-image-abc-123",
+		PullImages: true,
+	}
+
+	_, err = r.Run(ctx, opts)
+
+	// We expect this to fail, but because of registry failure,
+	// NOT because of a local image lookup failure.
+	if err == nil {
+		t.Fatal("Expected error when running non-existent image with PullImages: true, but got none")
+	}
+
+	// Verify the error is NOT "image not found" from local lookup.
+	// The local lookup error comes from client.GetImage.
+	// The pull error comes from client.Pull.
+	if strings.Contains(err.Error(), "image") && strings.Contains(err.Error(), "not found") {
+		t.Errorf("Expected pull error, but got local lookup error: %v", err)
+	}
+}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -35,8 +35,14 @@ func (r *DockerRuntime) Close() error {
 
 // Run pulls the image, creates, and starts a container with the given options.
 func (r *DockerRuntime) Run(ctx context.Context, opts runtime.RunOptions) (runtime.Container, error) {
-	if err := r.pullImage(ctx, opts.Image); err != nil {
-		return nil, fmt.Errorf("pull %s: %w", opts.Image, err)
+	if opts.PullImages {
+		if err := r.pullImage(ctx, opts.Image); err != nil {
+			return nil, fmt.Errorf("pull %s: %w", opts.Image, err)
+		}
+	} else {
+		if _, err := r.client.ImageInspect(ctx, opts.Image); err != nil {
+			return nil, fmt.Errorf("image %s not found: %w", opts.Image, err)
+		}
 	}
 
 	containerConfig, err := r.buildContainerConfig(opts)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -46,6 +46,7 @@ type RunOptions struct {
 	PortBindings map[Port][]PortBinding
 	Mounts       []Mount
 	Labels       map[string]string
+	PullImages   bool
 	LogLine      func(stream, line string) // nil = no logging
 }
 


### PR DESCRIPTION
Normal itestcontainer expectation is that the build system (Bazel) has
already loaded the image into the local Docker or containerd runtime, so
itestcontainer does not pull from a (remote) registry.  Doing otherwise
would break the hermeticity assumptions of the build.

However this may be desired, so a flag can be used to opt into this behaviour.